### PR TITLE
Step1: 마일스톤 조회 및 등록

### DIFF
--- a/github-issue/src/App.jsx
+++ b/github-issue/src/App.jsx
@@ -1,23 +1,12 @@
-import React, { useState, useEffect } from "react";
-import { getLabels } from "./api/api";
+import React from "react";
 import Main from "./components/Main/Main";
 import Header from "./components/Header/Header";
 
 const App = () => {
-  const [labels, setLabels] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const labelData = await getLabels();
-      setLabels(() => [...labelData]);
-    };
-    fetchData();
-  }, []);
-
   return (
     <>
       <Header />
-      <Main labels={labels} setLabels={setLabels}/>
+      <Main />
     </>
   );
 };

--- a/github-issue/src/Context/Context.js
+++ b/github-issue/src/Context/Context.js
@@ -1,3 +1,5 @@
 import React from "react";
 
+export const LabelsContext = React.createContext();
+
 export const MilestonesContext = React.createContext();

--- a/github-issue/src/Hooks/Hooks.js
+++ b/github-issue/src/Hooks/Hooks.js
@@ -1,0 +1,33 @@
+import { useState, useEffect } from "react";
+import { getLabels, getMilestones } from "../api/api";
+import { NAV_MANU } from "../utils/constants";
+import { delay } from "../utils/utils";
+
+const { LABELS } = NAV_MANU;
+
+const useFetch = (type) => {
+  const [state, setState] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const fetchData =
+          type === LABELS ? await getLabels() : await getMilestones();
+        setState([...fetchData]);
+      } catch (e) {
+        console.error("exeception occuer", e.message);
+      } finally {
+        await delay(3000);
+        setLoading(false);
+      }
+    })();
+  }, [type]);
+
+  return {
+    state,
+    loading,
+  };
+};
+
+export default useFetch;

--- a/github-issue/src/api/api.js
+++ b/github-issue/src/api/api.js
@@ -51,3 +51,8 @@ export const deleteLabels = async (id) => {
   const message = deleteMessageForm();
   await request(`${API_ENDPOINT}${URL.LABELS}/${id}`, message);
 };
+
+export const getMilestones = async () => {
+  const milestoneData = await request(`${API_ENDPOINT}${URL.MILESTONES}`);
+  return milestoneData;
+};

--- a/github-issue/src/api/api.js
+++ b/github-issue/src/api/api.js
@@ -39,7 +39,8 @@ export const getLabels = async () => {
 
 export const postLabels = async (data) => {
   const message = postMessageForm(data, "POST");
-  await request(`${API_ENDPOINT}${URL.LABELS}`, message);
+  const newLabelData = await request(`${API_ENDPOINT}${URL.LABELS}`, message);
+  return newLabelData;
 };
 
 export const editLabels = async (data, id) => {
@@ -55,4 +56,13 @@ export const deleteLabels = async (id) => {
 export const getMilestones = async () => {
   const milestoneData = await request(`${API_ENDPOINT}${URL.MILESTONES}`);
   return milestoneData;
+};
+
+export const postMilestones = async (data) => {
+  const message = postMessageForm(data, "POST");
+  const newMilestoneData = await request(
+    `${API_ENDPOINT}${URL.MILESTONES}`,
+    message
+  );
+  return newMilestoneData;
 };

--- a/github-issue/src/api/api.js
+++ b/github-issue/src/api/api.js
@@ -4,9 +4,9 @@ const URL = {
   MILESTONES: "/milestones",
 };
 
-const postMessageForm = (data, type) => {
+const postMessageForm = (data, methodType) => {
   return {
-    method: type ? "POST" : "PUT",
+    method: methodType,
     body: JSON.stringify(data),
     headers: {
       "Content-Type": "application/json",
@@ -38,12 +38,12 @@ export const getLabels = async () => {
 };
 
 export const postLabels = async (data) => {
-  const message = postMessageForm(data, true);
+  const message = postMessageForm(data, "POST");
   await request(`${API_ENDPOINT}${URL.LABELS}`, message);
 };
 
 export const editLabels = async (data, id) => {
-  const message = postMessageForm(data, false);
+  const message = postMessageForm(data, "PUT");
   await request(`${API_ENDPOINT}${URL.LABELS}/${id}`, message);
 };
 

--- a/github-issue/src/components/Buttons/OperateButton.jsx
+++ b/github-issue/src/components/Buttons/OperateButton.jsx
@@ -12,9 +12,9 @@ const Button = styled.div`
   background-color: ${({ buttonType }) => buttonType ? "#31c453" : "#ebedf1"};
 `
 
-const OperateButton = ({ name, setNewLabelFlag, newLabelFlag, buttonType }) => {
+const OperateButton = ({ name, setNewTypeFlag, newTypeFlag, buttonType }) => {
   const toggleNewLabelFlag = () => {
-    setNewLabelFlag(!newLabelFlag)
+    setNewTypeFlag(!newTypeFlag)
   }
   return (
     <Button buttonType={buttonType} onClick={toggleNewLabelFlag}>

--- a/github-issue/src/components/Buttons/SubmitButton.jsx
+++ b/github-issue/src/components/Buttons/SubmitButton.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import styled from "styled-components";
+
+const SubmitButton = ({ name }) => {
+  return (
+    <Button type="submit">
+      {name}
+    </Button>
+  )
+}
+
+const Button = styled.button`
+  position: relative;
+  border: 1px solid #fff;
+  padding: 10px 16px;
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  color: #fff;
+  background-color: #31c453;
+`
+
+export default SubmitButton;

--- a/github-issue/src/components/Buttons/TypeButton.jsx
+++ b/github-issue/src/components/Buttons/TypeButton.jsx
@@ -16,9 +16,11 @@ const Button = styled.div`
   background-color: ${({ typeFlag }) => typeFlag ? "#0f65d7" : "#fff"};
 `
 
-const TypeButton = ({ name, typeFlag, setType }) => {
+const TypeButton = ({ name, typeFlag, type, setType, setNewTypeFlag }) => {
   const toggleType = () => {
+    if (name === type) return
     setType(name)
+    setNewTypeFlag(false)
   }
   
   return (

--- a/github-issue/src/components/Labels/LabelItem.jsx
+++ b/github-issue/src/components/Labels/LabelItem.jsx
@@ -39,8 +39,8 @@ const LabelItem = ({ id, name, description, color, setLabels }) => {
         </LabelButtonWrapper>
       </LabelItemWrapper>
       <LabelsFormSection 
-        newLabelFlag={editLabelFlag}
-        setNewLabelFlag={setEditLabelFlag}
+        newTypeFlag={editLabelFlag}
+        setNewTypeFlag={setEditLabelFlag}
         setLabels={setLabels}
         labelItemData={labelItemData}
         onClickDeleteLabel={onClickDeleteLabel}

--- a/github-issue/src/components/Labels/LabelItem.jsx
+++ b/github-issue/src/components/Labels/LabelItem.jsx
@@ -4,7 +4,7 @@ import { getLabels, deleteLabels } from "../../api/api"
 
 import Label from "./Label";
 import LabelsFormSection from './LabelsFormSection';
-import { LabelsContext } from "./LabelsContext";
+import { LabelsContext } from "../../Context/Context";
 
 const LabelItem = ({ id, name, description, color }) => {
   const { labelsDispatch } = useContext(LabelsContext)

--- a/github-issue/src/components/Labels/LabelItem.jsx
+++ b/github-issue/src/components/Labels/LabelItem.jsx
@@ -4,7 +4,7 @@ import { getLabels, deleteLabels } from "../../api/api"
 
 import Label from "./Label";
 import LabelsFormSection from './LabelsFormSection';
-import { LabelsContext } from "./LabelsWrapper";
+import { LabelsContext } from "./LabelsContext";
 
 const LabelItem = ({ id, name, description, color }) => {
   const { labelsDispatch } = useContext(LabelsContext)

--- a/github-issue/src/components/Labels/LabelItem.jsx
+++ b/github-issue/src/components/Labels/LabelItem.jsx
@@ -1,11 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import { getLabels, deleteLabels } from "../../api/api"
 
 import Label from "./Label";
 import LabelsFormSection from './LabelsFormSection';
+import { LabelsContext } from "./LabelsWrapper";
 
-const LabelItem = ({ id, name, description, color, setLabels }) => {
+const LabelItem = ({ id, name, description, color }) => {
+  const { labelsDispatch } = useContext(LabelsContext)
   const [editLabelFlag, setEditLabelFlag] = useState(false)
   const labelItemData = {
     id, 
@@ -19,7 +21,7 @@ const LabelItem = ({ id, name, description, color, setLabels }) => {
     e.preventDefault()
     await deleteLabels(id)
     const labelData = await getLabels()
-    setLabels(() => [...labelData])
+    labelsDispatch({ type: "SET_LABELS", payload: [...labelData] })
     if (editLabelFlag) {
       setEditLabelFlag(false)
     }
@@ -41,7 +43,6 @@ const LabelItem = ({ id, name, description, color, setLabels }) => {
       <LabelsFormSection 
         newTypeFlag={editLabelFlag}
         setNewTypeFlag={setEditLabelFlag}
-        setLabels={setLabels}
         labelItemData={labelItemData}
         onClickDeleteLabel={onClickDeleteLabel}
       />

--- a/github-issue/src/components/Labels/LabelList.jsx
+++ b/github-issue/src/components/Labels/LabelList.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
 import LabelItem from "./LabelItem";
-import { LabelsContext } from "./LabelsContext";
+import { LabelsContext } from "../../Context/Context";
 
 const LabelList = () => {
   const { labelsState: { labels } } = useContext(LabelsContext)

--- a/github-issue/src/components/Labels/LabelList.jsx
+++ b/github-issue/src/components/Labels/LabelList.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
 import LabelItem from "./LabelItem";
-import { LabelsContext } from "./LabelsWrapper";
+import { LabelsContext } from "./LabelsContext";
 
 const LabelList = () => {
   const { labelsState: { labels } } = useContext(LabelsContext)

--- a/github-issue/src/components/Labels/LabelList.jsx
+++ b/github-issue/src/components/Labels/LabelList.jsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
 import LabelItem from "./LabelItem";
+import { LabelsContext } from "./LabelsWrapper";
 
-const LabelList = ({ labels, setLabels }) => {
+const LabelList = () => {
+  const { labelsState: { labels } } = useContext(LabelsContext)
   const labelItem = labels.map((label) =>{
     const { id, name, description, color } = label
     return (
@@ -12,7 +14,6 @@ const LabelList = ({ labels, setLabels }) => {
         description={description} 
         color={color} 
         key={label.id}
-        setLabels={setLabels}
       />
     )
   })

--- a/github-issue/src/components/Labels/LabelsContext.js
+++ b/github-issue/src/components/Labels/LabelsContext.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const LabelsContext = React.createContext();

--- a/github-issue/src/components/Labels/LabelsContext.js
+++ b/github-issue/src/components/Labels/LabelsContext.js
@@ -1,3 +1,0 @@
-import React from "react";
-
-export const LabelsContext = React.createContext();

--- a/github-issue/src/components/Labels/LabelsFormSection.jsx
+++ b/github-issue/src/components/Labels/LabelsFormSection.jsx
@@ -5,7 +5,7 @@ import { selectColor } from "../../utils/utils"
 import { getLabels, postLabels, editLabels } from "../../api/api"
 
 import Label from "./Label"
-import { LabelsContext } from "./LabelsWrapper";
+import { LabelsContext } from "./LabelsContext";
 import OperateButton from "../Buttons/OperateButton"
 
 const initialFormData = {

--- a/github-issue/src/components/Labels/LabelsFormSection.jsx
+++ b/github-issue/src/components/Labels/LabelsFormSection.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import { LABEL_FORM, BUTTON_NAME, DEFALUT_VALUE } from "../../utils/constants"
 import { selectColor } from "../../utils/utils"
 import { getLabels, postLabels, editLabels } from "../../api/api"
 
 import Label from "./Label"
+import { LabelsContext } from "./LabelsWrapper";
 import OperateButton from "../Buttons/OperateButton"
 
 const initialFormData = {
@@ -16,13 +17,13 @@ const initialFormData = {
 const LabelsFormSection = ({ 
   newTypeFlag, 
   setNewTypeFlag, 
-  setLabels, 
   labelItemData = {
     ...initialFormData,
     id: null
   }, 
   onClickDeleteLabel 
 }) => {
+  const { labelsDispatch } = useContext(LabelsContext)
   const { 
     id: editFlag, 
     name: editName, 
@@ -60,7 +61,7 @@ const LabelsFormSection = ({
     e.preventDefault()
     editFlag ? await editLabels(formData, editFlag) : await postLabels(formData)
     const labelData = await getLabels()
-    setLabels(() => [...labelData])
+    labelsDispatch({ type: "SET_LABELS", payload: [...labelData] })
     setNewTypeFlag(false)
     setFormData({
       ...initialFormData,

--- a/github-issue/src/components/Labels/LabelsFormSection.jsx
+++ b/github-issue/src/components/Labels/LabelsFormSection.jsx
@@ -7,15 +7,19 @@ import { getLabels, postLabels, editLabels } from "../../api/api"
 import Label from "./Label"
 import OperateButton from "../Buttons/OperateButton"
 
+const initialFormData = {
+  name: "",
+  description: "",
+  color: DEFALUT_VALUE.DEFAULT_COLOR
+}
+
 const LabelsFormSection = ({ 
-  newLabelFlag, 
-  setNewLabelFlag, 
+  newTypeFlag, 
+  setNewTypeFlag, 
   setLabels, 
   labelItemData = {
-    id: null,
-    name: "",
-    description: "",
-    color: DEFALUT_VALUE.DEFAULT_COLOR
+    ...initialFormData,
+    id: null
   }, 
   onClickDeleteLabel 
 }) => {
@@ -57,17 +61,16 @@ const LabelsFormSection = ({
     editFlag ? await editLabels(formData, editFlag) : await postLabels(formData)
     const labelData = await getLabels()
     setLabels(() => [...labelData])
-    setNewLabelFlag(false)
+    setNewTypeFlag(false)
     setFormData({
-      name: "",
-      description: "",
-      color: DEFALUT_VALUE.DEFAULT_COLOR
+      ...initialFormData,
     })
+    setButtonFlag(true)
   }
 
   return (
     <Wrapper 
-      newLabelFlag={newLabelFlag}
+      newTypeFlag={newTypeFlag}
       editFlag={editFlag}
     >
       <Header>
@@ -118,8 +121,8 @@ const LabelsFormSection = ({
             <OperateButton 
               name={BUTTON_NAME.CANCEL} 
               buttonType={false} 
-              setNewLabelFlag={setNewLabelFlag} 
-              newLabelFlag={setNewLabelFlag}
+              setNewTypeFlag={setNewTypeFlag} 
+              newTypeFlag={newTypeFlag}
             />
             <SubmitButton disabled={buttonFlag}>{createLabel}</SubmitButton>
           </FormOperationWrapper>
@@ -130,7 +133,8 @@ const LabelsFormSection = ({
 };
 
 const Wrapper = styled.div`
-  display: ${({ newLabelFlag }) => newLabelFlag ? "block" : "none" };
+  display: ${({ newTypeFlag }) => newTypeFlag ? "block" : "none" };
+  margin-bottom: ${({ newTypeFlag }) => newTypeFlag ? "32px" : "0" };
   width: 100%;
   padding: 24px;
   background-color: ${({ editFlag }) => editFlag ? "#fff" : "#ebedf1"};

--- a/github-issue/src/components/Labels/LabelsFormSection.jsx
+++ b/github-issue/src/components/Labels/LabelsFormSection.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import { LABEL_FORM, BUTTON_NAME, DEFALUT_VALUE } from "../../utils/constants"
 import { selectColor } from "../../utils/utils"
@@ -7,19 +7,36 @@ import { getLabels, postLabels, editLabels } from "../../api/api"
 import Label from "./Label"
 import OperateButton from "../Buttons/OperateButton"
 
-const LabelsFormSection = ({ newLabelFlag, setNewLabelFlag, setLabels, labelItemData, onClickDeleteLabel }) => {
-  const [buttonFlag, setButtonFlag] = useState(true)
-  const [formData, setFormData] = useState({
+const LabelsFormSection = ({ 
+  newLabelFlag, 
+  setNewLabelFlag, 
+  setLabels, 
+  labelItemData = {
+    id: null,
     name: "",
     description: "",
     color: DEFALUT_VALUE.DEFAULT_COLOR
+  }, 
+  onClickDeleteLabel 
+}) => {
+  const { 
+    id: editFlag, 
+    name: editName, 
+    description: editDescription, 
+    color: editColor 
+  } = labelItemData
+  const [buttonFlag, setButtonFlag] = useState(editFlag ? false : true)
+  const [formData, setFormData] = useState({
+    name: editName,
+    description: editDescription,
+    color: editColor
   })
   const { name, description, color } = formData
-  const createLabel = labelItemData ? BUTTON_NAME.SAVE_CHANGES : BUTTON_NAME.CREATE_LABEL
+  const createLabel = labelItemData.id ? BUTTON_NAME.SAVE_CHANGES : BUTTON_NAME.CREATE_LABEL
   
   const onChangeData = (e) => {
     const { value, name } = e.target
-    if (name === "name") name === "name" && value ? setButtonFlag(false) : setButtonFlag(true)
+    if (name === "name") value ? setButtonFlag(false) : setButtonFlag(true)
       
     setFormData({
       ...formData,
@@ -37,7 +54,7 @@ const LabelsFormSection = ({ newLabelFlag, setNewLabelFlag, setLabels, labelItem
 
   const onSubmitFormData = async (e) => {
     e.preventDefault()
-    labelItemData ? await editLabels(formData, labelItemData.id) : await postLabels(formData)
+    editFlag ? await editLabels(formData, editFlag) : await postLabels(formData)
     const labelData = await getLabels()
     setLabels(() => [...labelData])
     setNewLabelFlag(false)
@@ -48,24 +65,10 @@ const LabelsFormSection = ({ newLabelFlag, setNewLabelFlag, setLabels, labelItem
     })
   }
 
-  useEffect(() => {
-    if (!labelItemData) return
-    const labelFormData = () => {
-      const { name, description, color } = labelItemData
-      setFormData({
-        name: name,
-        description: description,
-        color: color
-      })
-      setButtonFlag(false)
-    }
-    labelFormData();
-  }, [labelItemData])
-
   return (
     <Wrapper 
       newLabelFlag={newLabelFlag}
-      labelItemData={labelItemData}
+      editFlag={editFlag}
     >
       <Header>
         <Label 
@@ -73,7 +76,7 @@ const LabelsFormSection = ({ newLabelFlag, setNewLabelFlag, setLabels, labelItem
           color={color}
         />
         <Button 
-          labelItemData={labelItemData}
+          editFlag={editFlag}
           onClick={onClickDeleteLabel}
         >
           Delete
@@ -130,7 +133,7 @@ const Wrapper = styled.div`
   display: ${({ newLabelFlag }) => newLabelFlag ? "block" : "none" };
   width: 100%;
   padding: 24px;
-  background-color: ${({ labelItemData }) => labelItemData ? "#fff" : "#ebedf1"};
+  background-color: ${({ editFlag }) => editFlag ? "#fff" : "#ebedf1"};
   border: 1px solid #dbdee2
 `
 
@@ -140,7 +143,7 @@ const Header = styled.div`
 `
 
 const Button = styled.button`
-  display: ${({ labelItemData }) => labelItemData ? "block" : "none"};
+  display: ${({ editFlag }) => editFlag ? "block" : "none"};
   cursor: pointer;
   border: none;
   background: none;

--- a/github-issue/src/components/Labels/LabelsFormSection.jsx
+++ b/github-issue/src/components/Labels/LabelsFormSection.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useContext } from "react";
 import styled from "styled-components";
 import { LABEL_FORM, BUTTON_NAME, DEFALUT_VALUE } from "../../utils/constants"
-import { selectColor } from "../../utils/utils"
+import { selectColor } from "../../utils/utils";
 import { getLabels, postLabels, editLabels } from "../../api/api"
 
-import Label from "./Label"
-import { LabelsContext } from "./LabelsContext";
-import OperateButton from "../Buttons/OperateButton"
+import Label from "./Label";
+import { LabelsContext } from "../../Context/Context";
+import OperateButton from "../Buttons/OperateButton";
 
 const initialFormData = {
   name: "",

--- a/github-issue/src/components/Labels/LabelsWrapper.jsx
+++ b/github-issue/src/components/Labels/LabelsWrapper.jsx
@@ -1,12 +1,18 @@
 import React from "react";
 import styled from "styled-components";
 import LabelList from "./LabelList";
+import LabelsFormSection from "./LabelsFormSection";
 
-const LabelsWrapper = ({ labels, setLabels }) => {
+const LabelsWrapper = ({ labels, setLabels, newTypeFlag, setNewTypeFlag }) => {
   const labelLength = labels.length
   
   return (
     <>
+      <LabelsFormSection 
+        newTypeFlag={newTypeFlag} 
+        setNewTypeFlag={setNewTypeFlag}
+        setLabels={setLabels}
+      />
       <Header>{labelLength} labels</Header>
       <LabelList 
         labels={labels} 

--- a/github-issue/src/components/Labels/LabelsWrapper.jsx
+++ b/github-issue/src/components/Labels/LabelsWrapper.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useReducer } from "react";
 import styled from "styled-components";
 import { getLabels } from "../../api/api";
-import { LabelsContext } from "./LabelsContext"
+import { LabelsContext } from "../../Context/Context";
 import LabelList from "./LabelList";
 import LabelsFormSection from "./LabelsFormSection";
 

--- a/github-issue/src/components/Labels/LabelsWrapper.jsx
+++ b/github-issue/src/components/Labels/LabelsWrapper.jsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect, useReducer } from "react";
 import styled from "styled-components";
 import { getLabels } from "../../api/api";
+import { LabelsContext } from "./LabelsContext"
 import LabelList from "./LabelList";
 import LabelsFormSection from "./LabelsFormSection";
-
-export const LabelsContext = React.createContext();
 
 const initialLabelState = { labels: [] };
 
@@ -48,3 +47,5 @@ const Header = styled.div`
   font-weight: bold;
   font-size: 16px;
 `
+
+export default LabelsWrapper;

--- a/github-issue/src/components/Labels/LabelsWrapper.jsx
+++ b/github-issue/src/components/Labels/LabelsWrapper.jsx
@@ -1,24 +1,40 @@
-import React from "react";
+import React, { useState, useEffect, useReducer } from "react";
 import styled from "styled-components";
+import { getLabels } from "../../api/api";
 import LabelList from "./LabelList";
 import LabelsFormSection from "./LabelsFormSection";
 
-const LabelsWrapper = ({ labels, setLabels, newTypeFlag, setNewTypeFlag }) => {
-  const labelLength = labels.length
+export const LabelsContext = React.createContext();
+
+const initialLabelState = { labels: [] };
+
+const labelReducer = (state, action) => {
+  switch (action.type) {
+    case "SET_LABELS":
+      return { labels: [...action.payload] }
+  }
+}
+
+export const LabelsWrapper = ({ newTypeFlag, setNewTypeFlag }) => {
+  const [labelsState, labelsDispatch] = useReducer(labelReducer, initialLabelState)
+  const { labels } = labelsState
+  useEffect(() => {
+    const fetchData = async () => {
+      const labelData = await getLabels();
+      labelsDispatch({ type: "SET_LABELS", payload: [...labelData] })
+    };
+    fetchData();
+  }, []);
   
   return (
-    <>
+    <LabelsContext.Provider value={{ labelsState, labelsDispatch }}>
       <LabelsFormSection 
         newTypeFlag={newTypeFlag} 
         setNewTypeFlag={setNewTypeFlag}
-        setLabels={setLabels}
       />
-      <Header>{labelLength} labels</Header>
-      <LabelList 
-        labels={labels} 
-        setLabels={setLabels}
-      />
-    </>
+      <Header>{labels.length} labels</Header>
+      <LabelList />
+    </LabelsContext.Provider>
   )
 }
 
@@ -32,5 +48,3 @@ const Header = styled.div`
   font-weight: bold;
   font-size: 16px;
 `
-
-export default LabelsWrapper;

--- a/github-issue/src/components/Labels/LabelsWrapper.jsx
+++ b/github-issue/src/components/Labels/LabelsWrapper.jsx
@@ -11,6 +11,8 @@ const labelReducer = (state, action) => {
   switch (action.type) {
     case "SET_LABELS":
       return { labels: [...action.payload] }
+    default:
+      throw new Error();
   }
 }
 

--- a/github-issue/src/components/Main/Main.jsx
+++ b/github-issue/src/components/Main/Main.jsx
@@ -31,7 +31,7 @@ const Main = () => {
       {
         renderTypeComponent({
           renderType: type,
-          props: type === NAV_MANU.LABELS ? { newTypeFlag, setNewTypeFlag } : { newTypeFlag, setNewTypeFlag }
+          props: { newTypeFlag, setNewTypeFlag }
         })
       }
     </MainSection>

--- a/github-issue/src/components/Main/Main.jsx
+++ b/github-issue/src/components/Main/Main.jsx
@@ -5,7 +5,7 @@ import { NAV_MANU } from "../../utils/constants"
 
 
 import Navbar from "../Navbar/Navbar";
-import { LabelsWrapper } from "../Labels/LabelsWrapper";
+import LabelsWrapper from "../Labels/LabelsWrapper";
 import MilestonesWrapper from "../Milestones/MilestonesWrapper";
 
 const renderTypeComponent = ({ renderType, props }) => {

--- a/github-issue/src/components/Main/Main.jsx
+++ b/github-issue/src/components/Main/Main.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import { NAV_MANU } from "../../utils/constants"
-import { getLabels } from "../../api/api";
+
 
 import Navbar from "../Navbar/Navbar";
-import LabelsWrapper from "../Labels/LabelsWrapper";
+import { LabelsWrapper } from "../Labels/LabelsWrapper";
 import MilestonesWrapper from "../Milestones/MilestonesWrapper";
 
 const renderTypeComponent = ({ renderType, props }) => {
@@ -18,18 +18,8 @@ const renderTypeComponent = ({ renderType, props }) => {
 
 const Main = () => {
   const [type, setType] = useState(NAV_MANU.LABELS);
-  const [labels, setLabels] = useState([]);
-  const [milestones, setMilestones] = useState([]);
   const [newTypeFlag, setNewTypeFlag] = useState(false);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const labelData = await getLabels();
-      setLabels(() => [...labelData]);
-    };
-    fetchData();
-  }, []);
-  
   return (
     <MainSection>
       <Navbar 
@@ -41,7 +31,7 @@ const Main = () => {
       {
         renderTypeComponent({
           renderType: type,
-          props: type === NAV_MANU.LABELS ? { labels, setLabels, newTypeFlag, setNewTypeFlag } : { milestones, setMilestones, newTypeFlag, setNewTypeFlag }
+          props: type === NAV_MANU.LABELS ? { newTypeFlag, setNewTypeFlag } : { newTypeFlag, setNewTypeFlag }
         })
       }
     </MainSection>

--- a/github-issue/src/components/Main/Main.jsx
+++ b/github-issue/src/components/Main/Main.jsx
@@ -1,33 +1,56 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 import { NAV_MANU } from "../../utils/constants"
+import { getLabels } from "../../api/api";
 
 import Navbar from "../Navbar/Navbar";
 import LabelsWrapper from "../Labels/LabelsWrapper";
+import MilestonesWrapper from "../Milestones/MilestonesWrapper";
 
-const MainSection = styled.section`
-  width: 80%;
-  margin: 0 auto;
-`
+const renderTypeComponent = ({ renderType, props }) => {
+  const TypeComponent = { 
+    [NAV_MANU.LABELS]: LabelsWrapper, 
+    [NAV_MANU.MILESTONES]: MilestonesWrapper 
+  }[renderType]
+  return <TypeComponent {...props} />
+}
 
-const Main = ({ labels, setLabels }) => {
-  const [type, setType] = useState(NAV_MANU.LABELS)
+const Main = () => {
+  const [type, setType] = useState(NAV_MANU.LABELS);
+  const [labels, setLabels] = useState([]);
+  const [milestones, setMilestones] = useState([]);
+  const [newTypeFlag, setNewTypeFlag] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const labelData = await getLabels();
+      setLabels(() => [...labelData]);
+    };
+    fetchData();
+  }, []);
   
   return (
     <MainSection>
       <Navbar 
         type={type} 
         setType={setType}
-        labels={labels}
-        setLabels={setLabels}
+        newTypeFlag={newTypeFlag}
+        setNewTypeFlag={setNewTypeFlag}
       />
-      <LabelsWrapper
-        labels={labels}
-        setLabels={setLabels}
-      />
+      {
+        renderTypeComponent({
+          renderType: type,
+          props: type === NAV_MANU.LABELS ? { labels, setLabels, newTypeFlag, setNewTypeFlag } : { milestones, setMilestones, newTypeFlag, setNewTypeFlag }
+        })
+      }
     </MainSection>
   );
 };
+
+const MainSection = styled.section`
+  width: 80%;
+  margin: 0 auto;
+`
 
 export default Main;

--- a/github-issue/src/components/Milestones/MilestonesContext.js
+++ b/github-issue/src/components/Milestones/MilestonesContext.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const MilestonesContext = React.createContext();

--- a/github-issue/src/components/Milestones/MilestonesFormSection.jsx
+++ b/github-issue/src/components/Milestones/MilestonesFormSection.jsx
@@ -1,10 +1,15 @@
 import React, { useState, useContext } from "react";
-import styled from "styled-components";
 import { postMilestones } from "../../api/api"
 import { MilestonesContext } from "../../Context/Context"
 import { BUTTON_NAME } from "../../utils/constants"
 import OperateButton from "../Buttons/OperateButton"
 import SubmitButton from "../Buttons/SubmitButton"
+import { 
+  FormSection, 
+  Form, 
+  LabelWrapper, 
+  FormOperationWrapper 
+} from "./MilestonesFormSection.style"
 
 const TITLE = "Title"
 const DUE_DATE = "Due date"
@@ -96,42 +101,5 @@ const MilestonesFormSection = ({ newTypeFlag, setNewTypeFlag }) => {
     </>
   )
 }
-
-const FormSection = styled.form`
-
-`
-
-const Form = styled.div`
-  padding: 16px 0;
-  border-top: 1px solid #dbdee2;
-  border-bottom: 1px solid #dbdee2;
-`
-
-const LabelWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  label {
-    font-weight: bold;
-    margin: 8px 0;
-  }
-
-  input {
-    width: 500px;
-    padding: 8px;
-    font-size: 20px;
-  }
-
-  textarea {
-    width: 600px;
-    height: 300px;
-    font-size: 20px;
-  }
-`
-
-const FormOperationWrapper = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`
 
 export default MilestonesFormSection;

--- a/github-issue/src/components/Milestones/MilestonesFormSection.jsx
+++ b/github-issue/src/components/Milestones/MilestonesFormSection.jsx
@@ -1,0 +1,137 @@
+import React, { useState, useContext } from "react";
+import styled from "styled-components";
+import { postMilestones } from "../../api/api"
+import { MilestonesContext } from "../../Context/Context"
+import { BUTTON_NAME } from "../../utils/constants"
+import OperateButton from "../Buttons/OperateButton"
+import SubmitButton from "../Buttons/SubmitButton"
+
+const TITLE = "Title"
+const DUE_DATE = "Due date"
+const DESCRIPTION = "Description"
+const OPTIONAL = "optional"
+const CREATE_MILESTONE = "Create milestone"
+
+const initialFormData = {
+  title: "",
+  date: "",
+  description: "",
+  status: "open"
+}
+
+const MilestonesFormSection = ({ newTypeFlag, setNewTypeFlag }) => {
+  const { milestoneDispatch } = useContext(MilestonesContext)
+  const [milestonesFormData, setMilestonesFormData] = useState({
+    title: "",
+    date: "",
+    description: "",
+    status: "open"
+  })
+
+  const { title, date, description } = milestonesFormData
+
+  const onMilestonesFormDataChange = ({ target }) => {
+    const { value, name } = target
+    setMilestonesFormData({
+      ...milestonesFormData,
+      [name]: value
+    })
+  }
+
+  const onFormDataSubmit = async (e) =>{
+    e.preventDefault()
+    const newMilestoneData = await postMilestones(milestonesFormData)
+    milestoneDispatch({ type: "SET_NEW_MILESTONES", payload: newMilestoneData })
+    setNewTypeFlag(false)
+    setMilestonesFormData({
+      ...initialFormData
+    })
+  }
+
+  return (
+    <>
+      <FormSection onSubmit={onFormDataSubmit}>
+        <Form>
+          <LabelWrapper>
+            <label>{TITLE}</label>
+            <input 
+              onChange={onMilestonesFormDataChange}
+              type="text"
+              name="title"
+              placeholder={TITLE}
+              value={title}
+            />
+          </LabelWrapper>
+          <LabelWrapper>
+            <label>{DUE_DATE + ` (${OPTIONAL})`}</label>
+            <input 
+              onChange={onMilestonesFormDataChange}
+              type="text"
+              name="date"
+              placeholder="연도. 월. 일."
+              value={date}
+            />
+          </LabelWrapper>
+          <LabelWrapper>
+            <label>{DESCRIPTION + ` (${OPTIONAL})`}</label>
+            <textarea 
+              onChange={onMilestonesFormDataChange}
+              name="description" 
+              cols="30" 
+              rows="10"
+              value={description}
+            ></textarea>
+          </LabelWrapper>
+        </Form>
+        <FormOperationWrapper>
+          <OperateButton 
+            name={BUTTON_NAME.CANCEL} 
+            buttonType={false} 
+            setNewTypeFlag={setNewTypeFlag} 
+            newTypeFlag={newTypeFlag}
+          />
+          <SubmitButton name={CREATE_MILESTONE} />
+        </FormOperationWrapper>
+      </FormSection>
+    </>
+  )
+}
+
+const FormSection = styled.form`
+
+`
+
+const Form = styled.div`
+  padding: 16px 0;
+  border-top: 1px solid #dbdee2;
+  border-bottom: 1px solid #dbdee2;
+`
+
+const LabelWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    font-weight: bold;
+    margin: 8px 0;
+  }
+
+  input {
+    width: 500px;
+    padding: 8px;
+    font-size: 20px;
+  }
+
+  textarea {
+    width: 600px;
+    height: 300px;
+    font-size: 20px;
+  }
+`
+
+const FormOperationWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`
+
+export default MilestonesFormSection;

--- a/github-issue/src/components/Milestones/MilestonesFormSection.style.js
+++ b/github-issue/src/components/Milestones/MilestonesFormSection.style.js
@@ -1,0 +1,36 @@
+import styled from "styled-components";
+
+export const FormSection = styled.form``;
+
+export const Form = styled.div`
+  padding: 16px 0;
+  border-top: 1px solid #dbdee2;
+  border-bottom: 1px solid #dbdee2;
+`;
+
+export const LabelWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    font-weight: bold;
+    margin: 8px 0;
+  }
+
+  input {
+    width: 500px;
+    padding: 8px;
+    font-size: 20px;
+  }
+
+  textarea {
+    width: 600px;
+    height: 300px;
+    font-size: 20px;
+  }
+`;
+
+export const FormOperationWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/github-issue/src/components/Milestones/MilestonesItem.jsx
+++ b/github-issue/src/components/Milestones/MilestonesItem.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+import { MILESTONES_STATUS } from "../../utils/constants";
+import { changeDateToDueDate } from "../../utils/utils";
+
+const MilestonesItem = ({ milestone }) => {
+  const { title, date, description } = milestone
+  return (
+    <MilestonesItemWrapper>
+      <MilestonesItemColumn>
+        <h2>{title}</h2>
+        <p>Due by {changeDateToDueDate(date)}</p>
+        <p>{description}</p>
+      </MilestonesItemColumn>
+      <MilestonesItemColumn>
+        <div>progressbar</div>
+        <div>status</div>
+        <div>
+          <button>Edit</button>
+          <button>Close</button>
+          <button>Delete</button>
+        </div>
+      </MilestonesItemColumn>
+    </MilestonesItemWrapper>
+  )
+};
+
+const MilestonesItemWrapper = styled.li`
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  border: 1px solid #dbdee2;
+
+  h2 {
+    margin: 0;
+  }
+`
+
+const MilestonesItemColumn = styled.div`
+  width: 50%;
+`
+
+export default MilestonesItem;

--- a/github-issue/src/components/Milestones/MilestonesList.jsx
+++ b/github-issue/src/components/Milestones/MilestonesList.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from "react";
+import styled from "styled-components";
+import MilestonesItem from "./MilestonesItem";
+import { MilestonesContext } from "./MilestonesContext";
+import { MILESTONES_STATUS } from "../../utils/constants";
+
+const { OPEN, CLOSED } = MILESTONES_STATUS
+
+const milestonesItem = (milestones) => {
+  return milestones.map(milestone => <MilestonesItem key={milestone.id} milestone={milestone} />)
+}
+
+const MilestonesList = ({ milestoneStatus }) => {
+  const { milestoneState: { milestones } } = useContext(MilestonesContext)
+  const { openMilestones, closedMilestones } = milestones
+  const milestonesType = {
+    [OPEN]: openMilestones,
+    [CLOSED]: closedMilestones
+  }
+
+  return (
+    <MilestonesListWrapper>
+      {
+        milestonesItem(milestonesType[milestoneStatus])
+      }
+    </MilestonesListWrapper>
+  )
+};
+
+const MilestonesListWrapper = styled.ul`
+
+`
+
+export default MilestonesList;

--- a/github-issue/src/components/Milestones/MilestonesList.jsx
+++ b/github-issue/src/components/Milestones/MilestonesList.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
 import MilestonesItem from "./MilestonesItem";
-import { MilestonesContext } from "./MilestonesContext";
+import { MilestonesContext } from "../../Context/Context";
 import { MILESTONES_STATUS } from "../../utils/constants";
 
 const { OPEN, CLOSED } = MILESTONES_STATUS

--- a/github-issue/src/components/Milestones/MilestonesListHeader.jsx
+++ b/github-issue/src/components/Milestones/MilestonesListHeader.jsx
@@ -1,0 +1,56 @@
+import React, { useContext, useEffect } from "react";
+import styled from "styled-components";
+import { MilestonesContext } from "./MilestonesContext";
+import { MILESTONES_STATUS } from "../../utils/constants"
+
+const { OPEN, CLOSED } = MILESTONES_STATUS
+
+const MilestonesListHeader = ({ milestoneStatus, setMilestoneStatus }) => {
+  const { milestoneState: { milestones } } = useContext(MilestonesContext)
+  const { openMilestones, closedMilestones } = milestones
+  
+  const milestonesStatusCounts = {
+    [OPEN]: openMilestones.length,
+    [CLOSED]: closedMilestones.length
+  }
+
+  const onToggleMilestoneStatusClick = (value) => setMilestoneStatus(value)
+
+  return (
+    <Header>
+      {
+        [OPEN, CLOSED].map(value => 
+          <Button 
+            key={value} 
+            milestoneStatusFlag={value === milestoneStatus}
+            onClick={() => onToggleMilestoneStatusClick(value)}
+          >
+            {milestonesStatusCounts[value]} {value}
+          </Button>
+        )
+      }
+      
+    </Header>
+  )
+};
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  height: 60px;
+  background-color: #ebedf1;
+  border: 1px solid #dbdee2;
+  padding-left: 16px;
+  font-weight: bold;
+  font-size: 16px;
+`
+
+const Button = styled.div`
+  cursor: pointer;
+  color: ${({ milestoneStatusFlag }) => milestoneStatusFlag ? "#000" : "#dbdee2"};
+  & + & {
+    margin-left: 16px;
+  }
+`
+
+export default MilestonesListHeader;

--- a/github-issue/src/components/Milestones/MilestonesListHeader.jsx
+++ b/github-issue/src/components/Milestones/MilestonesListHeader.jsx
@@ -1,7 +1,7 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import styled from "styled-components";
-import { MilestonesContext } from "./MilestonesContext";
-import { MILESTONES_STATUS } from "../../utils/constants"
+import { MilestonesContext } from "../../Context/Context";
+import { MILESTONES_STATUS } from "../../utils/constants";
 
 const { OPEN, CLOSED } = MILESTONES_STATUS
 

--- a/github-issue/src/components/Milestones/MilestonesListSection.jsx
+++ b/github-issue/src/components/Milestones/MilestonesListSection.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import { MILESTONES_STATUS } from "../../utils/constants"
+import MilestonesListHeader from "./MilestonesListHeader";
+import MilestonesList from "./MilestonesList";
+
+const { OPEN } = MILESTONES_STATUS
+
+const MilestonesListSection = ({ newTypeFlag, setNewTypeFlag }) => {
+  const [milestoneStatus, setMilestoneStatus] = useState(OPEN)
+  
+  return (
+    <>
+      <MilestonesListHeader 
+        milestoneStatus={milestoneStatus}
+        setMilestoneStatus={setMilestoneStatus}
+      />
+      <MilestonesList 
+        milestoneStatus={milestoneStatus}
+      />
+    </>
+  )
+}
+
+export default MilestonesListSection;

--- a/github-issue/src/components/Milestones/MilestonesWrapper.jsx
+++ b/github-issue/src/components/Milestones/MilestonesWrapper.jsx
@@ -1,10 +1,48 @@
-import React from "react";
+import React, { useEffect, useReducer } from "react";
+import { getMilestones } from '../../api/api';
+import { MilestonesContext } from "./MilestonesContext";
+import MilestonesFormSection from "./MilestonesFormSection";
+import MilestonesListSection from "./MilestonesListSection";
 
-const MilestonesWrapper = (props) => {
+const initailMilestoneState = { milestones: {} };
+
+const milestoneReducer = (state, action) => {
+  switch (action.type) {
+    case "SET_MILESTONES":
+      return { milestones: {...action.payload} };
+    default:
+      throw new Error();
+  }
+}
+
+const renderMilestonesWrapper = ({ renderType, props }) => {
+  const MilestonesComponent = renderType ? MilestonesFormSection : MilestonesListSection
+  return <MilestonesComponent {...props} />
+}
+
+const MilestonesWrapper = ({ newTypeFlag, setNewTypeFlag }) => {
+  const [milestoneState, milestoneDispatch] = useReducer(milestoneReducer, initailMilestoneState);
+  
+  useEffect(() => {
+    const getMilestonesData = async () => {
+      const milestoneData = await getMilestones();
+      milestoneDispatch({ type: "SET_MILESTONES", payload: {
+        openedMilestones: [...milestoneData.filter(item => item.status === "open")],
+        closedMilestones: [...milestoneData.filter(item => item.status === "close")]
+      } });
+    };
+    getMilestonesData();
+  }, [])
+
   return (
-    <>
-      마일스톤
-    </>
+    <MilestonesContext.Provider value={{ milestoneState, milestoneDispatch }}>
+      {
+        renderMilestonesWrapper({
+          renderType: newTypeFlag,
+          props: { newTypeFlag, setNewTypeFlag }
+        })
+      }
+    </MilestonesContext.Provider>
   )
 }
 

--- a/github-issue/src/components/Milestones/MilestonesWrapper.jsx
+++ b/github-issue/src/components/Milestones/MilestonesWrapper.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const MilestonesWrapper = (props) => {
+  return (
+    <>
+      마일스톤
+    </>
+  )
+}
+
+export default MilestonesWrapper;

--- a/github-issue/src/components/Milestones/MilestonesWrapper.jsx
+++ b/github-issue/src/components/Milestones/MilestonesWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useReducer } from "react";
 import { getMilestones } from '../../api/api';
-import { MilestonesContext } from "./MilestonesContext";
+import { MilestonesContext } from "../../Context/Context";
 import MilestonesFormSection from "./MilestonesFormSection";
 import MilestonesListSection from "./MilestonesListSection";
 
@@ -13,6 +13,8 @@ const milestoneReducer = (state, action) => {
   switch (action.type) {
     case "SET_MILESTONES":
       return { milestones: {...action.payload} };
+    case "SET_NEW_MILESTONES":
+      return { milestones: {...state.milestones, openMilestones: [...state.milestones.openMilestones, action.payload]} }
     default:
       throw new Error();
   }

--- a/github-issue/src/components/Milestones/MilestonesWrapper.jsx
+++ b/github-issue/src/components/Milestones/MilestonesWrapper.jsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useReducer } from "react";
 import { getMilestones } from '../../api/api';
 import { MilestonesContext } from "../../Context/Context";
+import { NAV_MANU } from "../../utils/constants";
 import MilestonesFormSection from "./MilestonesFormSection";
 import MilestonesListSection from "./MilestonesListSection";
+import useFetch from "../../Hooks/Hooks";
+
+const { MILESTONES } = NAV_MANU
 
 const initailMilestoneState = { milestones: {
   openMilestones: [],
@@ -27,17 +31,17 @@ const renderMilestonesWrapper = ({ renderType, props }) => {
 
 const MilestonesWrapper = ({ newTypeFlag, setNewTypeFlag }) => {
   const [milestoneState, milestoneDispatch] = useReducer(milestoneReducer, initailMilestoneState);
-  
+  const { state, loading } = useFetch(MILESTONES);
+
   useEffect(() => {
     const getMilestonesData = async () => {
-      const milestoneData = await getMilestones();
       milestoneDispatch({ type: "SET_MILESTONES", payload: {
-        openMilestones: [...milestoneData.filter(item => item.status === "open")],
-        closedMilestones: [...milestoneData.filter(item => item.status === "close")]
+        openMilestones: [...state.filter(item => item.status === "open")],
+        closedMilestones: [...state.filter(item => item.status === "close")]
       } });
     };
     getMilestonesData();
-  }, [])
+  }, [state])
 
   return (
     <MilestonesContext.Provider value={{ milestoneState, milestoneDispatch }}>

--- a/github-issue/src/components/Milestones/MilestonesWrapper.jsx
+++ b/github-issue/src/components/Milestones/MilestonesWrapper.jsx
@@ -4,7 +4,10 @@ import { MilestonesContext } from "./MilestonesContext";
 import MilestonesFormSection from "./MilestonesFormSection";
 import MilestonesListSection from "./MilestonesListSection";
 
-const initailMilestoneState = { milestones: {} };
+const initailMilestoneState = { milestones: {
+  openMilestones: [],
+  closedMilestones: []
+} };
 
 const milestoneReducer = (state, action) => {
   switch (action.type) {
@@ -27,7 +30,7 @@ const MilestonesWrapper = ({ newTypeFlag, setNewTypeFlag }) => {
     const getMilestonesData = async () => {
       const milestoneData = await getMilestones();
       milestoneDispatch({ type: "SET_MILESTONES", payload: {
-        openedMilestones: [...milestoneData.filter(item => item.status === "open")],
+        openMilestones: [...milestoneData.filter(item => item.status === "open")],
         closedMilestones: [...milestoneData.filter(item => item.status === "close")]
       } });
     };

--- a/github-issue/src/components/Navbar/Navbar.jsx
+++ b/github-issue/src/components/Navbar/Navbar.jsx
@@ -38,7 +38,6 @@ const LabelsNavbar = ({ type, setType, setLabels }) => {
         newLabelFlag={newLabelFlag} 
         setNewLabelFlag={setNewLabelFlag}
         setLabels={setLabels}
-        labelItemData={false}
       />
     </Navigation>
   )

--- a/github-issue/src/components/Navbar/Navbar.jsx
+++ b/github-issue/src/components/Navbar/Navbar.jsx
@@ -1,18 +1,15 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 
 import { NAV_MANU, BUTTON_NAME } from "../../utils/constants";
 
 import TypeButton from "../Buttons/TypeButton";
 import OperationButton from "../Buttons/OperateButton";
-import LabelsFormSection from "../Labels/LabelsFormSection";
 
-const Navbar = ({ type, setType, setLabels }) => {
-  const [newLabelFlag, setNewLabelFlag] = useState(false)
-
+const Navbar = ({ type, setType, newTypeFlag, setNewTypeFlag }) => {
   return (
     <Navigation>
-      <Wrapper newLabelFlag={newLabelFlag}>
+      <Wrapper newTypeFlag={newTypeFlag}>
         <Type>
           <TypeButton 
             name={NAV_MANU.LABELS} 
@@ -28,17 +25,12 @@ const Navbar = ({ type, setType, setLabels }) => {
         <div>
           <OperationButton 
             name={BUTTON_NAME.NEW_LABEL} 
-            setNewLabelFlag={setNewLabelFlag} 
-            newLabelFlag={newLabelFlag}
+            setNewTypeFlag={setNewTypeFlag} 
+            newTypeFlag={newTypeFlag}
             buttonType={true}
           />
         </div>
       </Wrapper>
-      <LabelsFormSection 
-        newLabelFlag={newLabelFlag} 
-        setNewLabelFlag={setNewLabelFlag}
-        setLabels={setLabels}
-      />
     </Navigation>
   )
 }

--- a/github-issue/src/components/Navbar/Navbar.jsx
+++ b/github-issue/src/components/Navbar/Navbar.jsx
@@ -7,7 +7,7 @@ import TypeButton from "../Buttons/TypeButton";
 import OperationButton from "../Buttons/OperateButton";
 import LabelsFormSection from "../Labels/LabelsFormSection";
 
-const LabelsNavbar = ({ type, setType, setLabels }) => {
+const Navbar = ({ type, setType, setLabels }) => {
   const [newLabelFlag, setNewLabelFlag] = useState(false)
 
   return (
@@ -48,10 +48,10 @@ const Navigation = styled.div`
 const Wrapper = styled.nav`
   display: flex;
   justify-content: space-between;
-  margin-bottom: ${({ newLabelFlag }) => "32px"};
+  margin-bottom: 32px;
 `
 const Type = styled.div`
   display: flex;
 `
       
-export default LabelsNavbar;
+export default Navbar;

--- a/github-issue/src/components/Navbar/Navbar.jsx
+++ b/github-issue/src/components/Navbar/Navbar.jsx
@@ -1,12 +1,16 @@
 import React from "react";
 import styled from "styled-components";
 
-import { NAV_MANU, BUTTON_NAME } from "../../utils/constants";
+import { NAV_MANU } from "../../utils/constants";
 
 import TypeButton from "../Buttons/TypeButton";
 import OperationButton from "../Buttons/OperateButton";
 
+const NEW_LABEL = "New label"
+const NEW_MILESTONE = "New milestone"
+
 const Navbar = ({ type, setType, newTypeFlag, setNewTypeFlag }) => {
+  const selectedNewType = type === NAV_MANU.LABELS ? NEW_LABEL : NEW_MILESTONE
   return (
     <Navigation>
       <Wrapper newTypeFlag={newTypeFlag}>
@@ -24,7 +28,7 @@ const Navbar = ({ type, setType, newTypeFlag, setNewTypeFlag }) => {
         </Type>
         <div>
           <OperationButton 
-            name={BUTTON_NAME.NEW_LABEL} 
+            name={selectedNewType} 
             setNewTypeFlag={setNewTypeFlag} 
             newTypeFlag={newTypeFlag}
             buttonType={true}

--- a/github-issue/src/components/Navbar/Navbar.jsx
+++ b/github-issue/src/components/Navbar/Navbar.jsx
@@ -11,20 +11,21 @@ const NEW_MILESTONE = "New milestone"
 
 const Navbar = ({ type, setType, newTypeFlag, setNewTypeFlag }) => {
   const selectedNewType = type === NAV_MANU.LABELS ? NEW_LABEL : NEW_MILESTONE
+  const renderTypeButton = ({ typeName, props }) => {
+    return typeName.map(name => <TypeButton key={name} name={name} typeFlag={type===name} {...props}></TypeButton>)
+  }
+  
   return (
     <Navigation>
       <Wrapper newTypeFlag={newTypeFlag}>
         <Type>
-          <TypeButton 
-            name={NAV_MANU.LABELS} 
-            typeFlag={type===NAV_MANU.LABELS}
-            setType={setType}
-          />
-          <TypeButton 
-            name={NAV_MANU.MILESTONES} 
-            typeFlag={type===NAV_MANU.MILESTONES} 
-            setType={setType} 
-          />
+          {
+            renderTypeButton({
+              typeName: [NAV_MANU.LABELS, NAV_MANU.MILESTONES],
+              props: { type, setType, setNewTypeFlag }
+            })
+          }
+          
         </Type>
         <div>
           <OperationButton 
@@ -38,6 +39,7 @@ const Navbar = ({ type, setType, newTypeFlag, setNewTypeFlag }) => {
     </Navigation>
   )
 }
+
 const Navigation = styled.div`
   margin: 32px 0;
 `

--- a/github-issue/src/utils/constants.js
+++ b/github-issue/src/utils/constants.js
@@ -10,7 +10,6 @@ export const NAV_MANU = {
 };
 
 export const BUTTON_NAME = {
-  NEW_LABEL: "New label",
   CANCEL: "Cancel",
   CREATE_LABEL: "Create label",
   EDIT: "Edit",
@@ -21,4 +20,24 @@ export const BUTTON_NAME = {
 export const DEFALUT_VALUE = {
   LABEL_PREVIEW: "Label preview",
   DEFAULT_COLOR: "#bfd4f2",
+};
+
+export const MILESTONES_STATUS = {
+  OPEN: "open",
+  CLOSED: "closed",
+};
+
+export const MONTH = {
+  1: "January",
+  2: "February",
+  3: "March",
+  4: "April",
+  5: "May",
+  6: "June",
+  7: "July",
+  8: "August",
+  9: "September",
+  10: "October",
+  11: "November",
+  12: "December",
 };

--- a/github-issue/src/utils/utils.js
+++ b/github-issue/src/utils/utils.js
@@ -1,9 +1,11 @@
-export const delay = (time) => {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      resolve("Success");
-    }, time);
-  });
+import { MONTH } from "./constants";
+
+export const delay = (time) =>
+  new Promise((resolve, reject) => setTimeout(() => resolve("Success"), time));
+
+export const changeDateToDueDate = (date) => {
+  const [year, month, day] = date.split(".");
+  return `${MONTH[Number(month)]} ${day}, ${year}`;
 };
 
 export const selectColor = () => {


### PR DESCRIPTION
* Label context API 리팩토링
* 마일스톤 조회
* 마일스톤 등록
* useFetch custom hooks

### Todo
* 로딩 컴포넌트 구현
* 마일스톤 수정
* 마일스톤 삭제
* 마일스톤 내 todo list 구현하기
* 마일스톤 등록시 date 유효성 검사
* Reducer 분기 및 코드 정리

### ❓ Question
* 게시글의 등록, 수정, 삭제 시, 다시 get요청으로 해당 게시글 목록을 불러와서 렌더링하는게 나을지, 아니면 어차피 등록, 수정, 삭제는 완료되었으니 다시 목록을 부르지 않고 변경된 부분만 View에서 수정하는게 나을지 궁금합니다.
* 개인적으로 추가적인 비즈니스 로직이 필요하다면, 변경사항이 있을 때 get 요청으로 리스트를 다시 불러오는게 맞고, 그 외의 경우에는 view 단에서 변경된 부분만 수정하는 것이 리소스를 줄일 수 있는 방법이라고 생각합니다!

### TMI
* 항상 코드리뷰 감사합니다.